### PR TITLE
Test installation and standalone SSPS in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ install:
 script:
   - cd run_ssps
   - snakemake --cores 1
+  - cat my_predictions.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: julia
+
+os:
+  - osx
+
+julia:
+  - 1.2
+
+notifications:
+  email: false
+
+script:
+  - cd julia-project
+  - julia --project=. 'using Pkg; Pkg.instantiate()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: julia
 
 os:
-  - osx
+  - linux
+#  - osx
 
 julia:
   - 1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
 
 script:
   - cd run_ssps
-  - snakemake
+  - snakemake --cores 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 
 os:
   - linux
-#  - osx
 
 julia:
   - 1.2
@@ -18,7 +17,7 @@ install:
   - source $HOME/miniconda/etc/profile.d/conda.sh
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda create -n ssps -c bioconda python=3.7 snakemake
+  - conda create -n ssps -c bioconda -c conda-forge python=3.7 snakemake
   - conda activate ssps
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ julia:
 notifications:
   email: false
 
+# Install Julia dependencies, Miniconda, and Snakemake
+install:
+  - julia --project=julia-project --eval 'using Pkg; Pkg.instantiate()'
+  - wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh --output-document miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source $HOME/miniconda/etc/profile.d/conda.sh
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda create -n ssps -c bioconda python=3.7 snakemake
+  - conda activate ssps
+
 script:
-  - cd julia-project
-  - julia --project=. --eval 'using Pkg; Pkg.instantiate()'
+  - cd run_ssps
+  - snakemake

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
 
 script:
   - cd run_ssps
-  - snakemake --cores 1
+  - snakemake --cores 2
   - cat my_predictions.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ notifications:
 
 script:
   - cd julia-project
-  - julia --project=. 'using Pkg; Pkg.instantiate()'
+  - julia --project=. --eval 'using Pkg; Pkg.instantiate()'

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Follow these steps to run SSPS on your dataset. You will need
 1. Install the **python3.7 dependencies** if you haven't already. Find detailed instructions above.
 2. `cd` to the `run_ssps` directory
 3. Configure the parameters in `ssps_config.yaml` as appropriate
-4. Run Snakemake: `$ snakemake --cores 1`. Increase 1 to increase maximum number of CPU cores to be used.
+4. Run Snakemake: `$ snakemake --cores 1`. Increase 1 to increase the maximum number of CPU cores to be used.
 
 
 # Licenses

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Follow these steps to run SSPS on your dataset. You will need
 1. Install the **python3.7 dependencies** if you haven't already. Find detailed instructions above.
 2. `cd` to the `run_ssps` directory
 3. Configure the parameters in `ssps_config.yaml` as appropriate
-4. run Snakemake: `$ snakemake`.
+4. Run Snakemake: `$ snakemake --cores 1`. Increase 1 to increase maximum number of CPU cores to be used.
 
 
 # Licenses

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Sparse Signaling Pathway Sampling
+[![Build Status](https://travis-ci.com/gitter-lab/ssps.svg?branch=master)](https://travis-ci.com/gitter-lab/ssps)
 
 Code related to the manuscript _Inferring Signaling Pathways with Probabilistic Programming_ (Merrell & Gitter, 2020) (under review).
 

--- a/run_ssps/ssps_config.yaml
+++ b/run_ssps/ssps_config.yaml
@@ -5,17 +5,16 @@ ts_file: "my_timeseries.csv" # Must be TAB SEPARATED (for now)
 prior_file: "my_prior.csv"   # Must be COMMA SEPARATED (for now)
 node_name_file: "node_names.json" # Optional. If included, must be a JSON list.
                                   # Otherwise, set to empty string: "".
-prediction_file: "my_predictions.json" 
+prediction_file: "my_predictions.csv" # TAB SEPARATED edge predictions
 
 temp_dir: "temp"
 
 # MCMC settings
 mcmc_hyperparams:
-    burnin: 0.5 
-    regression_deg: 1  
+    burnin: 0.5
+    regression_deg: 1
     max_samples: 100000
-    lambda_prop_std: 3.0 
+    lambda_prop_std: 3.0
     large_indeg: 20
     n_chains: 4
-    timeout: 300 
-
+    timeout: 300


### PR DESCRIPTION
Closes #5 

The tests will initially run only Julia 1.2 in Linux.  We can easily include multiple versions of Julia later.  macOS support may require debugging a couple package installation errors.  We would also need to make the Miniconda download OS-specific, which is straightforward.

I specified `snakemake --cores 1` in the test script and the installation instructions because the Snakefile specifies `threads=1`.  Should we expand the instructions to explain how to run with multiple cores?