### PR TITLE
Corrected an off-by-one issue in score denominator

### DIFF
--- a/julia-project/postprocess_samples.jl
+++ b/julia-project/postprocess_samples.jl
@@ -184,7 +184,7 @@ function evaluate_summary(whole_seqs::Vector{ChangepointVec}, stop_idxs;
                           burnin::Float64=0.5)
 
     burnin_idxs = [Int(floor(burnin*length(seq))) for seq in whole_seqs]
-    sums = [sum(cpv[burnin_idxs[i]:length(cpv)]) for (i, cpv) in enumerate(whole_seqs)]
+    sums = [sum(cpv[(burnin_idxs[i]+1):length(cpv)]) for (i, cpv) in enumerate(whole_seqs)]
     ns = [length(cpv) - burnin_idxs[i] for (i, cpv) in enumerate(whole_seqs)]
 
     return sum(sums) / sum(ns)


### PR DESCRIPTION
Fixes #10 

There was a simple off-by-one error in our edge probability calculation.

This has no effect on our AUCPR metrics.